### PR TITLE
Check camera permission before starting session

### DIFF
--- a/qrcode/ios/Classes/QRCaptureView.m
+++ b/qrcode/ios/Classes/QRCaptureView.m
@@ -34,27 +34,36 @@
         self.channel = channel;
         [registrar addMethodCallDelegate:self channel:channel];
         
-        AVCaptureVideoPreviewLayer *layer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
-        self.captureLayer = layer;
+        AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+        if(status == AVAuthorizationStatusAuthorized) {
+            
+            AVCaptureVideoPreviewLayer *layer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
+            self.captureLayer = layer;
+            
+            layer.backgroundColor = [UIColor yellowColor].CGColor;
+            [self.layer addSublayer:layer];
+            layer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+            
+            AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+            AVCaptureDeviceInput *input = [[AVCaptureDeviceInput alloc] initWithDevice:device error:nil];
+            AVCaptureMetadataOutput *output = [[AVCaptureMetadataOutput alloc] init];
+            [self.session addInput:input];
+            [self.session addOutput:output];
+            self.session.sessionPreset = AVCaptureSessionPresetHigh;
         
-        layer.backgroundColor = [UIColor yellowColor].CGColor;
-        [self.layer addSublayer:layer];
-        layer.videoGravity = AVLayerVideoGravityResizeAspectFill;
-        
-        AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
-        AVCaptureDeviceInput *input = [[AVCaptureDeviceInput alloc] initWithDevice:device error:nil];
-        AVCaptureMetadataOutput *output = [[AVCaptureMetadataOutput alloc] init];
-        [self.session addInput:input];
-        [self.session addOutput:output];
-        self.session.sessionPreset = AVCaptureSessionPresetHigh;
-       
-        output.metadataObjectTypes = output.availableMetadataObjectTypes;
-        [output setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
-        [output setMetadataObjectTypes:@[AVMetadataObjectTypeUPCECode, AVMetadataObjectTypeCode39Code, AVMetadataObjectTypeCode39Mod43Code,
-        AVMetadataObjectTypeEAN13Code, AVMetadataObjectTypeEAN8Code, AVMetadataObjectTypeCode93Code, AVMetadataObjectTypeCode128Code,
-        AVMetadataObjectTypePDF417Code, AVMetadataObjectTypeQRCode, AVMetadataObjectTypeAztecCode]];
-        
-        [self.session startRunning];
+            output.metadataObjectTypes = output.availableMetadataObjectTypes;
+            [output setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
+            [output setMetadataObjectTypes:@[AVMetadataObjectTypeUPCECode, AVMetadataObjectTypeCode39Code, AVMetadataObjectTypeCode39Mod43Code,
+            AVMetadataObjectTypeEAN13Code, AVMetadataObjectTypeEAN8Code, AVMetadataObjectTypeCode93Code, AVMetadataObjectTypeCode128Code,
+            AVMetadataObjectTypePDF417Code, AVMetadataObjectTypeQRCode, AVMetadataObjectTypeAztecCode]];
+            
+            [self.session startRunning];
+
+        } else {
+
+            UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Tips" message:@"Authorization is required to use the camera, please check your permission settings: Settings> Privacy> Camera" delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Ok", nil];
+                [alert show];
+        }
     }
     return self;
 }

--- a/qrcode/ios/Classes/QRCaptureView.m
+++ b/qrcode/ios/Classes/QRCaptureView.m
@@ -35,7 +35,7 @@
         [registrar addMethodCallDelegate:self channel:channel];
         
         AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
-        if(status == AVAuthorizationStatusAuthorized) {
+        if(status == AVAuthorizationStatusAuthorized || status == AVAuthorizationStatusNotDetermined) {
             
             AVCaptureVideoPreviewLayer *layer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
             self.captureLayer = layer;
@@ -59,7 +59,7 @@
             
             [self.session startRunning];
 
-        } else {
+        } else { 
 
             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Tips" message:@"Authorization is required to use the camera, please check your permission settings: Settings> Privacy> Camera" delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Ok", nil];
                 [alert show];


### PR DESCRIPTION
Make sure camera permission is authorized before running the camera, otherwise app will crash.

I am not too familiar to Objective-c but I did my best to get the permission status and check if camera is authorized before it runs the session. we run to an issue that if user denys camera permission, app immediately crashes.

It will look like this when there is no permission on iOS 
<img src="https://i.imgur.com/gaKP4qk.jpg" />

I will glad to hear about this PR and learn more about it. 

Thanks, 
Majid